### PR TITLE
Fix: Enable adding/editing/deleting task categories without page reload

### DIFF
--- a/src/components/settings/CategorySettings.tsx
+++ b/src/components/settings/CategorySettings.tsx
@@ -52,26 +52,10 @@ const CategorySettings: React.FC<CategorySettingsProps> = ({
 
 
   
-  const handleConfirmDelete = async () => {
-  // const handleConfirmDelete = () => {
+  const handleConfirmDelete = () => {
     if (categoryToDelete) {
-       if (!auth.currentUser) {
-        alert("User not authenticated!");
-        return;
-      }
-      try {
-          const userId = auth.currentUser.uid;
-          const newCategory = await settingsService.deleteCategory(userId, "activity", categoryToDelete.id);
-          // alert(`Category Deleted Successfully: ${categoryToDelete.name}`);
-          window.location.reload();
-        } catch (error) {
-          console.error("Error Deleted Category:", error);
-          alert("Failed to delete category");
-        }
-      
-      // if (!user || !name.trim()) return;
-      // onDelete(categoryToDelete.id);
-      // setCategoryToDelete(null);
+      onDelete(categoryToDelete.id);
+      setCategoryToDelete(null);
     }
   };
 

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -68,11 +68,90 @@ export const useCategories = (type: 'activity' | 'task') => {
     }
   };
 
+import { addDoc, doc, updateDoc, deleteDoc } from 'firebase/firestore'; // Import firestore methods
+import { settingsService } from '../services/settings.service'; // Import settingsService
+
+// ... (keep existing imports and code)
+
+export const useCategories = (type: 'activity' | 'task') => {
+  const { user } = useAuthState();
+  const [categories, setCategories] = useState<{ id: string; name: string }[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadCategories = useCallback(async () => {
+    if (!user) return;
+
+    try {
+      setLoading(true);
+      setError(null);
+
+      const fetchedCategories = await settingsService.getCategories(user.uid, type);
+
+      console.log(`Loaded ${type} categories:`, fetchedCategories);
+      setCategories(fetchedCategories);
+    } catch (err) {
+      console.error('Error loading categories:', err);
+      setError('Failed to load categories');
+    } finally {
+      setLoading(false);
+    }
+  }, [user, type]);
+
+  useEffect(() => {
+    if (user) {
+      loadCategories();
+    }
+  }, [loadCategories, user]);
+
+  const addCategory = async (name: string) => {
+    if (!user || !name.trim()) return null;
+
+    try {
+      const newCategoryData = await settingsService.addCategory(user.uid, type, name.trim());
+      const category = { id: newCategoryData.id, name: newCategoryData.name };
+      setCategories(prev => [...prev, category]);
+      return category;
+    } catch (err) {
+      console.error('Error adding category:', err);
+      setError(`Failed to add ${type} category`);
+      return null;
+    }
+  };
+
+  const updateCategory = async (id: string, name: string) => {
+    if (!user || !name.trim()) return;
+
+    try {
+      await settingsService.updateCategory(user.uid, type, id, name.trim());
+      setCategories(prev =>
+        prev.map(cat => (cat.id === id ? { ...cat, name: name.trim() } : cat))
+      );
+    } catch (err) {
+      console.error('Error updating category:', err);
+      setError(`Failed to update ${type} category`);
+    }
+  };
+
+  const deleteCategory = async (id: string) => {
+    if (!user) return;
+
+    try {
+      await settingsService.deleteCategory(user.uid, type, id);
+      setCategories(prev => prev.filter(cat => cat.id !== id));
+    } catch (err) {
+      console.error('Error deleting category:', err);
+      setError(`Failed to delete ${type} category`);
+    }
+  };
+
   return {
     categories,
     loading,
     error,
     addCategory,
+    updateCategory,
+    deleteCategory,
     refresh: loadCategories
   };
 };

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -33,7 +33,7 @@ const Settings = () => {
   const {
     categories: activityCategories,
     loading: loadingActivityCategories,
-    // addCategory: addActivityCategory,
+    addCategory: addActivityCategory, // Use directly from hook
     updateCategory: updateActivityCategory,
     deleteCategory: deleteActivityCategory
   } = useCategories('activity');
@@ -41,35 +41,10 @@ const Settings = () => {
   const {
     categories: taskCategories,
     loading: loadingTaskCategories,
-    addCategory: addTaskCategory,
+    addCategory: addTaskCategory, // Already using from hook
     updateCategory: updateTaskCategory,
     deleteCategory: deleteTaskCategory
   } = useCategories('task');
-  
-  // const addActivityCategory = async (category) => {
-  //   alert(`New Activity Category: ${category}`);
-  // }
-
-
-  const addActivityCategory = async (category: string) => {
-    if (!auth.currentUser) {
-      alert("User not authenticated!");
-      return;
-    }
-
-    try {
-      const userId = auth.currentUser.uid;
-      const newCategory = await settingsService.addCategory(userId, "activity", category);
-      
-      // alert(`New Activity Category Added: ${newCategory.name}`);
-      window.location.reload();
-    } catch (error) {
-      console.error("Error adding activity category:", error);
-      alert("Failed to add activity category");
-    }
-  };
-
-
   
   const handleCreateDummyData = async () => {
     if (!user) return;


### PR DESCRIPTION
- Refactored `useCategories` hook to include `updateCategory` and `deleteCategory` functions and use `settingsService` for all CRUD operations.
- Modified `Settings.tsx` to use the functions from `useCategories` for both activity and task categories consistently.
- Updated `CategorySettings.tsx` to correctly use the `onDelete` prop, removing direct service calls.
- This ensures that category changes are reflected in the UI immediately without requiring a page reload.